### PR TITLE
Recursively search for proto files in srcDir.

### DIFF
--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -186,7 +186,7 @@ class ProtobufPlugin implements Plugin<Project> {
 
             String srcDir = new File(project.projectDir.path + File.separator + 
                                      project.protobuf.src).canonicalPath
-            def srcProtoFiles = project.fileTree(srcDir).include('*.proto')
+            def srcProtoFiles = project.fileTree(srcDir).include('**/*.proto')
             def javaOutputDir = project.file(project.buildDir.path + File.separator + 
                                              project.protobuf.outputJava)
             def cppOutputDir = project.file(project.buildDir.path + File.separator + 


### PR DESCRIPTION
Prior to this change only proto files that were in the root of the source directory were found.
