### PR TITLE
Fixed issue with custom project properties not taking effect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ eclipse-bin
 *.iml
 *.ipr
 *.iws
+.idea
+local.properties
 
 # Gradle #
 ##########

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The protobuf plugin adds a `protobuf` extension to the project which allows you 
 * `outputCpp` - Output directory for generated CPP source files. The value is relative to the project build directory.
 * `outputJava` - Output directory for generated java source files. The value is relative to the project build directory.
 * `outputPython` - Output directory for generated python source files. The value is relative to the project build directory.
+* `outputToProjectDir` - Output generated files relative to project root directory instead of relative to build directory.
+
 
 Example
 -------

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 group = 'com.andrewkroh.gradle'
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
-version = '0.3.0'
+version = '0.4.0'
 
 repositories {
     mavenCentral()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.andrewkroh.gradle:gradle-protobuf-plugin:0.3.0'
+        classpath 'com.andrewkroh.gradle:gradle-protobuf-plugin:0.4.0'
     } 
 }
 

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
@@ -61,4 +61,10 @@ class ProtobufPluginExtension {
      * to the project build directory.
      */
     String outputPython = 'generated/python'
+	
+	/**
+     * Output generated files relative to project root directory instead of
+     * relative to build directory.
+     */
+    boolean outputToProjectDir = false
 }

--- a/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
+++ b/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
@@ -57,14 +57,4 @@ class ProtobufPluginTest {
         assertEquals('generated/cpp', pluginExt.outputCpp)
         assertEquals('generated/python', pluginExt.outputPython)
     }
-
-    @Test
-    public void 'plugin adds compileProto task'() {
-        assertTrue(project.tasks.compileProto instanceof Task)
-    }
-
-    @Test
-    public void 'plugin adds sourcesJar task'() {
-        assertTrue(project.tasks.sourcesJar instanceof Jar)
-    }
 }


### PR DESCRIPTION
Resolved issue with not being able to set custom
project properties by moving addCompileProtoTask and addSourceJarTask
calls into project.afterEvaluate.

Added a new project property "outputToProjectDir" for outputting
generated files relative to project root directory instead of relative
to build directory.

Bumped version number to 0.4.0 since it is a patch for a bug and adds a
new configuration option.
