### PR TITLE
new feature: deactivate/activate automatic dependency creation using ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .project
 .settings
 eclipse-bin
+bin
 
 # IntelliJ #
 ############

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The protobuf plugin adds a `protobuf` extension to the project which allows you 
 * `outputJava` - Output directory for generated java source files. The value is relative to the project build directory.
 * `outputPython` - Output directory for generated python source files. The value is relative to the project build directory.
 * `outputToProjectDir` - Output generated files relative to project root directory instead of relative to build directory. Defaults to false.
+* `autoDependency` - Activate or deactivate automatic dependency creation. If true, the dependency on the Java plugin is added automatically based on the Protocol Buffers version number. Defaults to true.
 
 Example
 -------

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'signing'
 group = 'com.andrewkroh.gradle'
 sourceCompatibility = 1.5
 targetCompatibility = 1.5
-version = '0.4.0'
+version = '0.5.0.alpha'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -166,15 +166,15 @@ class ProtobufPlugin implements Plugin<Project> {
     {
         if (project.protobuf.autoDependency) {
             // Add a dependency on the protocol buffer jar:
-			logger.info("Create dependency for protocol buffers automatically.")
+            logger.info("Create dependency for protocol buffers automatically.")
             project.dependencies {
                 compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
             }
         }
-		else
-		{
-			logger.info("Automatic dependecy creation deactivated!")
-		}
+        else
+        {
+            logger.info("Automatic dependecy creation deactivated!")
+        }
     }
 
     /**

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -164,10 +164,17 @@ class ProtobufPlugin implements Plugin<Project> {
     void addProtobufJarDependency(final Project project,
                                   final String protobufVersion)
     {
-        // Add a dependency on the protocol buffer jar:
-        project.dependencies {
-            compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
+        if (project.protobuf.autoDependency) {
+            // Add a dependency on the protocol buffer jar:
+			logger.info("Create dependency for protocol buffers automatically.")
+            project.dependencies {
+                compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
+            }
         }
+		else
+		{
+			logger.info("Automatic dependecy creation deactivated!")
+		}
     }
 
     /**

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPlugin.groovy
@@ -173,7 +173,7 @@ class ProtobufPlugin implements Plugin<Project> {
         }
         else
         {
-            logger.info("Automatic dependecy creation deactivated!")
+            logger.info("Automatic dependency creation deactivated!")
         }
     }
 

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
@@ -67,4 +67,11 @@ class ProtobufPluginExtension {
      * relative to build directory.
      */
     boolean outputToProjectDir = false
+	
+	/**
+	 * Activate or deactivate automatic dependency creation. Default is 'true',
+	 * i.e. the dependency is added automatically based on the compiler version.
+	 */
+	boolean autoDependency = true
+
 }

--- a/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
+++ b/src/main/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginExtension.groovy
@@ -67,11 +67,11 @@ class ProtobufPluginExtension {
      * relative to build directory.
      */
     boolean outputToProjectDir = false
-	
-	/**
-	 * Activate or deactivate automatic dependency creation. Default is 'true',
-	 * i.e. the dependency is added automatically based on the compiler version.
-	 */
-	boolean autoDependency = true
+    
+    /**
+     * Activate or deactivate automatic dependency creation. Default is 'true',
+     * i.e. the dependency is added automatically based on the compiler version.
+     */
+    boolean autoDependency = true
 
 }

--- a/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
+++ b/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
@@ -58,5 +58,6 @@ class ProtobufPluginTest {
         assertEquals('generated/cpp', pluginExt.outputCpp)
         assertEquals('generated/python', pluginExt.outputPython)
         assertFalse(pluginExt.outputToProjectDir)
+		assertTrue(pluginExt.autoDependency)
     }
 }

--- a/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
+++ b/src/test/groovy/com/andrewkroh/gradle/plugins/protobuf/ProtobufPluginTest.groovy
@@ -58,6 +58,6 @@ class ProtobufPluginTest {
         assertEquals('generated/cpp', pluginExt.outputCpp)
         assertEquals('generated/python', pluginExt.outputPython)
         assertFalse(pluginExt.outputToProjectDir)
-		assertTrue(pluginExt.autoDependency)
+        assertTrue(pluginExt.autoDependency)
     }
 }


### PR DESCRIPTION
... a property switch.

Reason: for testing the google protocol buffers 3.0.0 alpha the automatic dependency creation feature fails as the protoc version differs from the name of the runtime library. In order to allow the manual creation of the proper dependency, it was necessary for me to be able to deactivate the automatic creation.

Maybe this is useful for someone else as well ...

All the best,
l00tr
